### PR TITLE
code: Use entire snapshot_weightings series instead of just first entry

### DIFF
--- a/scripts/prepare_sector_network.py
+++ b/scripts/prepare_sector_network.py
@@ -2299,7 +2299,7 @@ def add_dac(n, costs):
 
 
 def add_services(n, costs):
-    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
+    temporal_resolution = n.snapshot_weightings.generators
     buses = spatial.nodes.intersection(n.loads_t.p_set.columns)
 
     profile_residential = normalize_by_country(
@@ -2468,8 +2468,7 @@ def p_set_from_scaling(col, scaling, energy_totals, nhours):
     """
     return (
         1e6
-        / nhours
-        * scaling.mul(energy_totals[col], level=0).droplevel(level=0, axis=1)
+        * scaling.div(nhours,level=0).mul(energy_totals[col], level=0).droplevel(level=0, axis=1)
     )
 
 
@@ -2480,7 +2479,7 @@ def add_residential(n, costs):
     # heat_demand_index=n.loads_t.p.filter(like='residential').filter(like='heat').dropna(axis=1).index
     # oil_res_index=n.loads_t.p.filter(like='residential').filter(like='oil').dropna(axis=1).index
 
-    temporal_resolution = n.snapshot_weightings.generators.iloc[0]
+    temporal_resolution = n.snapshot_weightings.generators
 
     heat_ind = (
         n.loads_t.p_set.filter(like="residential")


### PR DESCRIPTION
Thanks for raising the PR to fix the temporal loads. 

I have made some small modifications in this commit to use the entire snapshot weightings (as a series) instead of using just the first entry. I believe an option called `SEG` exists that can aggregate the model to have non-equidistant time periods. In those cases, using just the first entry will again lead to wrong load estimations

# Closes # (if applicable).

## Changes proposed in this Pull Request


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/configuration.rst` and `doc/tutorial.rst`.
- [ ] A note for the release notes `doc/release_notes.rst` is amended in the format of previous release notes, including reference to the requested PR.
